### PR TITLE
Revamp reconciler state

### DIFF
--- a/pkg/client/injection/reconciler/samples/v1alpha1/addressableservice/reconciler.go
+++ b/pkg/client/injection/reconciler/samples/v1alpha1/addressableservice/reconciler.go
@@ -184,7 +184,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 
-	if s.IsNOP(r.IsLeaderFor(s.NamespacedName())) {
+	s.SetLeader(r.IsLeaderFor(s.NamespacedName()))
+
+	if s.IsNOP() {
 		// Nothing to do.
 		return nil
 	}

--- a/pkg/client/injection/reconciler/samples/v1alpha1/addressableservice/reconciler.go
+++ b/pkg/client/injection/reconciler/samples/v1alpha1/addressableservice/reconciler.go
@@ -204,9 +204,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	// Get the resource with this namespace/name.
 
-	getter := r.Lister.AddressableServices(namespace)
+	getter := r.Lister.AddressableServices(s.Namespace)
 
-	original, err := getter.Get(name)
+	original, err := getter.Get(s.Name)
 
 	if errors.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.

--- a/pkg/client/injection/reconciler/samples/v1alpha1/addressableservice/state.go
+++ b/pkg/client/injection/reconciler/samples/v1alpha1/addressableservice/state.go
@@ -83,8 +83,7 @@ func (s *State) NamespacedName() types.NamespacedName {
 // IsNOP checks to see if this reconciler with the current state is enabled to
 // do any work or not.
 // IsNOP returns true when there is no work possible for the reconciler.
-func (s *State) IsNOP(isLeader bool) bool {
-	s.isLeader = isLeader
+func (s *State) IsNOP() bool {
 	if !s.isLeader && !s.isROI && !s.isROF {
 		// If we are not the leader, and we don't implement either ReadOnly
 		// interface, then take a fast-path out.
@@ -101,6 +100,10 @@ func (s *State) ShouldRecord(event *reconciler.ReconcilerEvent) bool {
 		return true
 	}
 	return false
+}
+
+func (s *State) SetLeader(isLeader bool) {
+	s.isLeader = isLeader
 }
 
 // IsLeader Implements knative.dev/pkg/reconciler/State.IsLeader

--- a/pkg/reconciler/addressableservice/addressableservice.go
+++ b/pkg/reconciler/addressableservice/addressableservice.go
@@ -36,7 +36,7 @@ import (
 // newReconciledNormal makes a new reconciler event with event type Normal, and
 // reason AddressableServiceReconciled.
 func newReconciledNormal(namespace, name string) reconciler.Event {
-	return reconciler.NewEvent(corev1.EventTypeNormal, "AddressableServiceReconciled", "AddressableService reconciled: \"%s/%s\"", namespace, name)
+	return reconciler.NewIfStatusUpdatedEvent(corev1.EventTypeNormal, "AddressableServiceReconciled", "AddressableService reconciled: \"%s/%s\"", namespace, name)
 }
 
 // Reconciler implements addressableservicereconciler.Interface for

--- a/pkg/reconciler/addressableservice/addressableservice.go
+++ b/pkg/reconciler/addressableservice/addressableservice.go
@@ -36,7 +36,7 @@ import (
 // newReconciledNormal makes a new reconciler event with event type Normal, and
 // reason AddressableServiceReconciled.
 func newReconciledNormal(namespace, name string) reconciler.Event {
-	return reconciler.NewIfStatusUpdatedEvent(corev1.EventTypeNormal, "AddressableServiceReconciled", "AddressableService reconciled: \"%s/%s\"", namespace, name)
+	return reconciler.NewEventIfStatusUpdated(corev1.EventTypeNormal, "AddressableServiceReconciled", "AddressableService reconciled: \"%s/%s\"", namespace, name)
 }
 
 // Reconciler implements addressableservicereconciler.Interface for

--- a/vendor/knative.dev/pkg/reconciler/events.go
+++ b/vendor/knative.dev/pkg/reconciler/events.go
@@ -60,8 +60,8 @@ func NewEvent(eventtype, reason, messageFmt string, args ...interface{}) Event {
 	}
 }
 
-// NewConditionalEvent returns an Event fully populated.
-func NewConditionalEvent(conditionFn ConditionalEventFn, eventtype, reason, messageFmt string, args ...interface{}) Event {
+// NewEventConditional returns an Event fully populated.
+func NewEventConditional(conditionFn ConditionalEventFn, eventtype, reason, messageFmt string, args ...interface{}) Event {
 	return &ReconcilerEvent{
 		EventType:   eventtype,
 		Reason:      reason,
@@ -73,14 +73,14 @@ func NewConditionalEvent(conditionFn ConditionalEventFn, eventtype, reason, mess
 
 // NewIfStatusUpdatedEvent returns an Event fully populated with the
 // conditional function set to watch for status updates from the leader.
-func NewIfStatusUpdatedEvent(eventtype, reason, messageFmt string, args ...interface{}) Event {
+func NewEventIfStatusUpdated(eventtype, reason, messageFmt string, args ...interface{}) Event {
 	return &ReconcilerEvent{
 		EventType: eventtype,
 		Reason:    reason,
 		Format:    messageFmt,
 		Args:      args,
-		ConditionFn: func(s *State) bool {
-			if s.IsStatusUpdated && s.IsLeader {
+		ConditionFn: func(s State) bool {
+			if s.IsStatusUpdated() && s.IsLeader() {
 				return true
 			}
 			return false
@@ -88,7 +88,12 @@ func NewIfStatusUpdatedEvent(eventtype, reason, messageFmt string, args ...inter
 	}
 }
 
-type ConditionalEventFn func(state *State) bool
+type State interface {
+	IsStatusUpdated() bool
+	IsLeader() bool
+}
+
+type ConditionalEventFn func(state State) bool
 
 // ReconcilerEvent wraps the fields required for recorders to create a
 // kubernetes recorder Event.

--- a/vendor/knative.dev/pkg/reconciler/events.go
+++ b/vendor/knative.dev/pkg/reconciler/events.go
@@ -79,8 +79,8 @@ func NewIfStatusUpdatedEvent(eventtype, reason, messageFmt string, args ...inter
 		Reason:    reason,
 		Format:    messageFmt,
 		Args:      args,
-		ConditionFn: func(f *Flags) bool {
-			if f.StatusUpdated && f.IsLeader {
+		ConditionFn: func(s *State) bool {
+			if s.IsStatusUpdated && s.IsLeader {
 				return true
 			}
 			return false

--- a/vendor/knative.dev/pkg/reconciler/state.go
+++ b/vendor/knative.dev/pkg/reconciler/state.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Veroute.on 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+// State is used to track the state of a reconciler in a single run.
+type State struct {
+	// Key is the original reconciliation key from the queue.
+	Key string
+	// Namespace is the namespace split from the reconciliation key.
+	Namespace string
+	// Namespace is the name split from the reconciliation key.
+	Name string
+
+	// IsROI (Read Only Interface) the reconciler only observes reconciliation.
+	IsROI bool
+	// IsROF (Read Only Finalizer) the reconciler only observes finalize.
+	IsROF bool
+	// IsLeader the instance of the reconciler is the elected leader.
+	IsLeader bool
+	// IsStatusUpdated the resource had its status updated successful.
+	IsStatusUpdated bool
+}
+
+func NewState(key string) (*State, error) {
+	// Convert the namespace/name string into a distinct namespace and name
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("invalid resource key: %s", key)
+	}
+	return &State{
+		Key:       key,
+		Namespace: namespace,
+		Name:      name,
+	}, nil
+}
+
+// NamespacedName is a helper to create a types.NamespacedName
+func (s *State) NamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: s.Namespace,
+		Name:      s.Name,
+	}
+}
+
+// IsNOP checks to see if this reconciler with the current state is enabled to
+// do any work or not.
+// IsNOP returns true when there is no work possible for the reconciler.
+func (s *State) IsNOP() bool {
+	if !s.IsLeader && !s.IsROI && !s.IsROF {
+		return true
+	}
+	return false
+}
+
+func (s *State) ShouldRecord(event *ReconcilerEvent) bool {
+	if event.ConditionFn == nil {
+		return true
+	}
+	if event.ConditionFn(s) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Preview of a change to the gen-reconciler to allow reconcilers that did no work to skip the normal event if no status update.