### PR TITLE
Move comments closer to the types they're supposed for

### DIFF
--- a/pkg/apis/samples/v1alpha1/addressable_service_types.go
+++ b/pkg/apis/samples/v1alpha1/addressable_service_types.go
@@ -23,12 +23,12 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+// AddressableService is a Knative abstraction that encapsulates the interface by which Knative
+// components express a desire to have a particular image cached.
+//
 // +genclient
 // +genreconciler
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// AddressableService is a Knative abstraction that encapsulates the interface by which Knative
-// components express a desire to have a particular image cached.
 type AddressableService struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -73,9 +73,9 @@ type AddressableServiceStatus struct {
 	Address *duckv1.Addressable `json:"address,omitempty"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 // AddressableServiceList is a list of AddressableService resources
+//
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type AddressableServiceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`


### PR DESCRIPTION
I'm always somewhat irritated if the comments are floating "somewhere". This gets them very close to the actual type to leave no doubt which type they apply to.

/assign @mattmoor @n3wscott 