### PR TITLE
Widen the golangci-lint checks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,14 @@ run:
 
 linters:
   enable:
-    - unconvert
+    - asciicheck
+    - errorlint
+    - golint
+    - gosec
     - prealloc
+    - stylecheck
+    - tparallel
+    - unconvert
+    - unparam
   disable:
     - errcheck


### PR DESCRIPTION
Taken these from Knative Serving. I think it makes sense to cast a fairly wide net by default and tune these down if needed.

/assign @mattmoor 