### PR TITLE
Apply security best-practices to the deployments

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -68,3 +68,11 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/samples
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -68,6 +68,14 @@ spec:
         - name: WEBHOOK_NAME
           value: webhook
 
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
+
         readinessProbe: &probe
           periodSeconds: 1
           httpGet:


### PR DESCRIPTION
Like deployments in Serving for example, the controller and webhook can run in a pretty stripped down fashion by default.

/assign @mattmoor 