### PR TITLE
Update config files

### DIFF
--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.knative-samples.knative.dev
@@ -26,9 +26,10 @@ webhooks:
       name: webhook
       namespace: knative-samples
   failurePolicy: Fail
+  sideEffects: None
   name: defaulting.webhook.knative-samples.knative.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.knative-samples.knative.dev
@@ -42,9 +43,10 @@ webhooks:
       name: webhook
       namespace: knative-samples
   failurePolicy: Fail
+  sideEffects: None
   name: validation.webhook.knative-samples.knative.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.knative-samples.knative.dev
@@ -58,6 +60,7 @@ webhooks:
       name: webhook
       namespace: knative-samples
   failurePolicy: Fail
+  sideEffects: None
   name: config.webhook.knative-samples.knative.dev
   namespaceSelector:
     matchExpressions:


### PR DESCRIPTION
This patch updates config file to use admissionregistration.k8s.io/v1.
Also this patch removes `istio-injection` annotation from `knative-samples` namespace.

The error without this patch:
```
$ kubectl apply -f config/500-webhook-configuration.yaml
Warning: admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
mutatingwebhookconfiguration.admissionregistration.k8s.io/defaulting.webhook.knative-samples.knative.dev created
Warning: admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration
validatingwebhookconfiguration.admissionregistration.k8s.io/validation.webhook.knative-samples.knative.dev created
validatingwebhookconfiguration.admissionregistration.k8s.io/config.webhook.knative-samples.knative.dev created
secret/webhook-certs created
```

/kind cleanup

**Release Note**

```release-note
webhook configuration is updated to admissionregistration.k8s.io/v1
```

Fix https://github.com/knative-sandbox/sample-controller/issues/436

/cc @dprotaso 
