### PR TITLE
Use a more conservative RBAC profile for sample-controller.

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -1,3 +1,17 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -9,6 +23,7 @@ aggregationRule:
   - matchLabels:
       samples.knative.dev/controller: "true"
 rules: [] # Rules are automatically filled in by the controller manager.
+
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -18,21 +33,73 @@ metadata:
     samples.knative.dev/release: devel
     samples.knative.dev/controller: "true"
 rules:
+  # Allow creating events associated with resources we are controlling.
   - apiGroups: [""]
-    resources: ["configmaps", "services", "secrets", "events", "pods"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+    resources: ["events"]
+    verbs: ["create"]
+
+  # Allow the reconciliation of exactly our validating webhooks.
+  # This is needed for us to patch in caBundle information.
   - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "update"]
+    resourceNames: ["config.webhook.knative-samples.knative.dev", "validation.webhook.knative-samples.knative.dev"]
+
+  # Allow the reconciliation of exactly our mutating webhooks.
+  # This is needed for us to patch in caBundle information.
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "update"]
+    resourceNames: ["defaulting.webhook.knative-samples.knative.dev"]
+
+  # Allow the reconciliation of exactly our CRDs.
+  # This is needed for us to patch in conversion webhook information.
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "update"]
+    resourceNames: ["addressableservices.samples.knative.dev", "simpledeployments.samples.knative.dev"]
+
+  # Allow us to reconcile our resources.
   - apiGroups: ["samples.knative.dev"]
     resources: ["*"]
-    verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]
+    verbs: ["get", "list", "update", "watch"]
+
+  # The webhook configured the namespace as the OwnerRef on various cluster-scoped resources,
+  # which requires we can Get the system namespace.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+    resourceNames: ["knative-samples"]
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # A separate cluster role for the things actually needed by this
+  # controller's contrived examples.
+  name: knative-samples-resources
+  labels:
+    samples.knative.dev/release: devel
+    samples.knative.dev/controller: "true"
+rules:
+  # AddressableService tracks services, so it needs to be able to list
+  # and watch those in whatever namespace folks create those CRDs in
+  # to do its job.
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch"]
+
+  # SimpleDeployment creates and manages Pods, so it needs broad
+  # permissions on pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "update", "delete", "watch"]

--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -1,0 +1,31 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-samples-namespace-rbac
+  namespace: knative-samples
+  labels:
+    samples.knative.dev/release: devel
+rules:
+  # Needed to watch and load configuration and secret data.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "update", "watch"]
+
+  # This is needed by leader election to run the controller in HA.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]

--- a/config/201-rolebinding.yaml
+++ b/config/201-rolebinding.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: knative-samples-namespace-rbac
+  namespace: knative-samples
+  labels:
+    samples.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-samples
+roleRef:
+  kind: Role
+  name: knative-samples-namespace-rbac
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This change has two key parts:
1. Reduce the RBAC profile for the sample-controller
2. Split the "common" needs that derive from our controller framework from the ancillary needs of the contrived sample resources.

For `1.` there are a few key elements:
* Reduce the `Lease`/`Secret`/`ConfigMap` needs to be a `Role` (vs. `ClusterRole`)
* For `{Validating,Mutating}WebhookConfiguration` and `CustomResourceDefinition` limit our ability to mutate things to our specific resources, since these are managed by singleton reconcilers.
* For `Namespace` restrict our access to `get` on just our namespace (used to fetch the UID for OwnerRefs)
* For `Event` just give `create` access, since I believe that's all we ever use

/kind cleanup

I _think_ @markusthoemmes will appreciate this cleanup 😇 

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
